### PR TITLE
Add Vedika API to APIs for Bot Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
       - [Node.js](#node)
       - [.NET](#net)
       - [Other Languages](#other-languages)
+      - [APIs for Bot Content](#apis-for-bot-content)
   
   
   ## About 
@@ -440,9 +441,14 @@
   
   
   ### Other Languages
-  
+
   - __[Haskell: haskell-telegram-api](https://github.com/klappvisor/haskell-telegram-api)__ : _High-level bindings to the Telegram Bot API based on servant library._
   - __[Dart: TeleDart](https://github.com/DinoLeung/TeleDart)__ : _A library interfacing with the latest Telegram Bot API._
+
+
+  ### APIs for Bot Content
+
+  - __[Vedika API](https://vedika.io)__ : _Vedic astrology API with AI chatbot for building horoscope, kundali, and panchang bots. 108+ endpoints, 22 languages, Python and JavaScript SDKs._
 
 
 <br><br>


### PR DESCRIPTION
## Description

Adding [Vedika API](https://vedika.io) under a new section "APIs for Bot Content" in Telegram Libraries.

**Vedika API** is a Vedic astrology API with AI chatbot capabilities, perfect for building:
- Horoscope bots (daily, weekly, monthly rashifal)
- Kundali (birth chart) generators
- Panchang (Hindu calendar) bots
- Kundali matching bots for matrimony platforms

### Key Features:
- 108+ API endpoints for comprehensive astrology calculations
- AI-powered chatbot for natural language astrology queries
- 22 language support (Hindi, Tamil, Bengali, Telugu, etc.)
- Free sandbox environment for development and testing
- Python and JavaScript SDKs available

### Changes:
- Added new subsection "APIs for Bot Content" under Telegram Libraries
- Updated Table of Contents to include the new section
- Added Vedika API entry with description

### Contribution Guidelines Followed:
- [x] Searched previous suggestions for duplicates
- [x] Individual pull request for this suggestion
- [x] Using proper format as per Contributing.md
- [x] Descriptions are short and end with period
- [x] Checked spelling and grammar
- [x] No emoji or images used

Repository: https://vedika.io