### PR TITLE
Add jellyfin-telegram-channel-sync to OpenSource Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@
   #### OpenSource Other Bots
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
+  - __[jellyfin-telegram-channel-sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync)__  By [GeiserX](https://github.com/GeiserX) : _Syncs Jellyfin user access with Telegram channel membership, automatically disabling accounts when members leave._
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
 
 


### PR DESCRIPTION
## Summary
- Adds [jellyfin-telegram-channel-sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) to the OpenSource Other Bots section.
- Syncs Jellyfin user access with Telegram channel membership, automatically disabling accounts when members leave.
- Entry placed in alphabetical order.<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about jellyfin-telegram-channel-sync to the list of available open-source bots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
