### PR TITLE
Add Broletter to OpenSource Other Bots

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2022 Hash Minner
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@
   - __[Youtube Dl bot](https://github.com/aryanvikash/Youtube-Downloader-Bot)__
   - __[X URL Uploader](https://github.com/X-Gorn/X-URL-Uploader)__ : _Telegram bot to upload HTTP/HTTPS direct link & youtube-dl, clone of TG-URL-Uploader_
   - __[All Url Uploader](https://github.com/kalanakt/All-Url-Uploader)__ : _A simple telegram Bot, Upload Media File| video To telegram using the direct download link. (youtube, Mediafire, google drive, mega drive, etc)._
+  - __[Telegram Nexus Bot](https://github.com/nexus-stc/stc)__ : _Allows users to access STC (library, search engine and AI tooling offering free access to academic knowledge and works of fictional literature) via Telegram_
 
   #### OpenSource File Store Bots
   - __[File sharing Bot](https://github.com/CodeXBotz/File-Sharing-Bot)__ : _Telegram Bot to store Posts and Documents and it can Access by Special Links._

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@
   - __[YukkiMusic Bot](https://github.com/TeamYukki/YukkiMusicBot)__ By [TeamYukki](https://github.com/TeamYukki) : _Telegram Group Calls Streaming bot with some useful features, written in Python with Pyrogram and Py-Tgcalls. Supporting platforms like Youtube, Spotify, Resso, AppleMusic, Soundcloud and M3u8 Links._
 
   #### OpenSource Other Bots
+  - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
   - __[Wikipedia Search](https://t.me/wiki)__ : _Search for wiki article in any chats or groups, no need to add it anywhere. Simply type @wiki in any chat, then type your query (without hitting 'send'). Bot will open a panel with Wikipedia article suggestions. Tap on an item to send it to your chat partner right away._
   - __[Livegram Bot](https://t.me/LivegramBot)__ : _Livegram Bot is a builder of feedback bots for Telegram. This can be used to broadcast messages, get feedback messages in groups, get bot statistics and more._
  - __[SUCH](https://t.me/such)__ : _feedback and support bot builder for channel admins, bot developers, business owners, and community managers._
+ - __[Code Stars](https://t.me/code_stars)__ : _Code Stars highlights the most popular GitHub repos from the last hour, helping you discover innovative projects early._
   
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@
         - [OpenSource File Store](#opensource-file-store-bots)
         - [OpenSource Music Bots](#opensource-music-bots)
         - [OpenSource Other Bots](#opensource-other-bots)
+
+	- [Telegram Bot Templates](#telegram-bot-templates)
+      - [Python](#python-bot-templates)
+      - [JavaScript](#javascript-bot-templates)
+      - [TypeScript](#typescript-bot-templates)
+      - [Go](#go-bot-templates)
+      - [PHP](#php-bot-templates)
+      - [Java](#java-bot-templates)
+      - [Rust](#rust-bot-templates)
    
     - [Telegram Libraries](#telegram-libraries)
       - [Java](#java)
@@ -263,6 +272,86 @@
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
+
+
+  ## Telegram Bot Templates
+
+  ### Python
+   - __[Forden/aiogram-bot-template](https://github.com/Forden/aiogram-bot-template)__ : Scalable aiogram bot template.
+   - __[AbirHasan2005/Pyrogram-Bot-Template](https://github.com/AbirHasan2005/Pyrogram-Bot-Template)__ : Pyrogram starter template.
+   - __[TelegramBots/telegram.bot](https://github.com/TelegramBots/telegram.bot)__ : Simple Python bot starter.
+   - __[delivrance/telegram-bot-heroku-template](https://github.com/delivrance/telegram-bot-heroku-template)__ : Heroku-ready Python Telegram bot template.
+	
+  ### JavaScript
+   - __[telegraf-inline-menu/template](https://github.com/telegraf-inline-menu/template)__ : Template for bots using Telegraf.js.
+   - __[yagop/node-telegram-bot-api/examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples)__ : Official node-telegram-bot-api examples.
+   - __[EdJoPaTo/telegram-bot-boilerplate](https://github.com/EdJoPaTo/telegram-bot-boilerplate)__ : Boilerplate for scalable JS Telegram bots.
+   - __[TediCross/TediCross](https://github.com/TediCross/TediCross)__ : Bridge template for Telegram/Discord in JS.
+	
+  ### TypeScript
+   - __[grammyjs/grammY-template](https://github.com/grammyjs/grammY-template)__ : TypeScript grammY bot template.
+   - __[Degreet/nestgram-template](https://github.com/Degreet/nestgram-template)__ : Nestgram starter for TS bots.
+   - __[grammyjs/typescript-template](https://github.com/grammyjs/typescript-template)__ : GrammY TypeScript template with best practices.
+	
+  ### Go
+   - __[mymmrac/telego-bot-template](https://github.com/mymmrac/telego-bot-template)__ : Telego bot template.
+   - __[go-telegram-bot-api/examples](https://github.com/go-telegram-bot-api/telegram-bot-api/tree/master/examples)__ : Official Go Telegram API examples.
+   - __[PaulSonOfLars/gotgbot-template](https://github.com/PaulSonOfLars/gotgbot-template)__ : Gotgbot starter template.
+	
+  ### PHP
+   - __[php-telegram-bot/example-bot](https://github.com/php-telegram-bot/example-bot)__ : Example bot with php-telegram-bot.
+   - __[nutgram/nutgram-template](https://github.com/nutgram/nutgram-template)__ : Nutgram bot starter.
+   - __[TelegramBot/Api](https://github.com/TelegramBot/Api)__ : PHP Telegram Bot API basic template.
+	
+  ### Java
+   - __[rubenlagus/TelegramBots ExampleBot](https://github.com/rubenlagus/TelegramBots/tree/master/TelegramBotsExample)__ : Java TelegramBots example.
+   - __[pengrad/java-telegram-bot-api/examples](https://github.com/pengrad/java-telegram-bot-api/tree/master/examples)__ : Java Telegram bot API examples.
+   - __[InsanusMokrassar/TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI/tree/master/examples)__ : Kotlin and Java bot API examples.
+	
+  ### Rust
+   - __[teloxide/teloxide-template](https://github.com/teloxide/teloxide-template)__ : Teloxide bot template.
+   - __[ayrat555/frankenstein/examples](https://github.com/ayrat555/frankenstein/tree/master/examples)__ : Frankenstein Rust bot examples.
+	
+  ### Kotlin
+   - __[vendelieu/telegram-bot-template](https://github.com/vendelieu/telegram-bot-template)__ : Kotlin Telegram bot starter.
+   - __[kotatogram/kotlin-telegram-bot-template](https://github.com/kotatogram/kotlin-telegram-bot-template)__ : Minimal Kotlin bot template.
+   - __[InsanusMokrassar/TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI/tree/master/examples)__ : Kotlin Telegram bot API examples.
+	
+  ### Node.js
+   - __[yagop/node-telegram-bot-api/examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples)__ : Node.js Telegram bot examples.
+   - __[telegraf/telegraf-template](https://github.com/telegraf/telegraf-template)__ : Telegraf.js bot starter template.
+   - __[grammyjs/grammY-template](https://github.com/grammyjs/grammY-template)__ : GrammY Node.js bot template.
+	
+  ### .NET
+   - __[TelegramBots/Telegram.Bot.Examples](https://github.com/TelegramBots/Telegram.Bot.Examples)__ : C#/.NET Telegram bot examples.
+   - __[RxTelegram/RxTelegram.Bot](https://github.com/RxTelegram/RxTelegram.Bot/tree/master/examples)__ : Reactive .NET bot examples.
+	
+  ### Swift
+   - __[rapierorg/telegram-bot-swift/Examples](https://github.com/rapierorg/telegram-bot-swift/tree/master/Examples)__ : Swift Telegram bot examples.
+   - __[nerzh/telegram-vapor-bot](https://github.com/nerzh/telegram-vapor-bot/tree/main/ExampleBot)__ : Vapor Swift bot example.
+	
+  ### Scala
+   - __[bot4s/telegram-sample-bot](https://github.com/bot4s/telegram-sample-bot)__ : Scala Telegram bot sample.
+   - __[augustjune/canoe](https://github.com/augustjune/canoe/tree/master/examples)__ : Functional Scala bot examples.
+	
+  ### Ruby
+   - __[telegram-bot-rb/telegram-bot-starter](https://github.com/telegram-bot-rb/telegram-bot-starter)__ : Ruby bot starter.
+   - __[atipugin/telegram-bot-ruby/examples](https://github.com/atipugin/telegram-bot-ruby/tree/master/examples)__ : Ruby Telegram bot API examples.
+	
+  ### C++
+   - __[reo7sp/tgbot-cpp-examples](https://github.com/reo7sp/tgbot-cpp/tree/master/examples)__ : C++ Telegram bot examples.
+   - __[egorpugin/tgbot/examples](https://github.com/egorpugin/tgbot/tree/master/examples)__ : Another C++ Telegram bot template.
+	
+  ### Elixir
+   - __[zhyu/nadia-example](https://github.com/zhyu/nadia-example)__ : Elixir Nadia bot example.
+   - __[rockneurotiko/ex_gram/examples](https://github.com/rockneurotiko/ex_gram/tree/master/examples)__ : ExGram Elixir bot examples.
+	
+  ### Dart
+   - __[DinoLeung/TeleDart/example](https://github.com/DinoLeung/TeleDart/tree/master/example)__ : TeleDart bot example.
+   - __[TelegramBots/telebot-dart](https://github.com/TelegramBots/telebot-dart/tree/master/example)__ : Dart Telebot example.
+	
+  ### Haskell
+   - __[klappvisor/haskell-telegram-api/examples](https://github.com/klappvisor/haskell-telegram-api/tree/master/examples)__ : Haskell Telegram bot examples.
 
 
   ## Telegram Libraries

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
   
   - __[Group Help](https://t.me/GroupHelpBot)__ : _This is the most complete Bot to help you manage your groups easily and safely!._
   - __[Rose](https://t.me/MissRose_bot)__ : _Powerful telegram bot to help you manage your groups._
-   __[InviteMemberBot ](https://t.me/InviteMemberBot )__ : _membership bot platform for paid Telegram channels and groups_
+  - __[InviteMemberBot ](https://t.me/InviteMemberBot )__ : _membership bot platform for paid Telegram channels and groups_
   ### Url Upload Bots
   
   - __[Video Download Bot](https://t.me/VideoDownloadBot)__ : _This Bot allows you to download videos from Facebook, Twitter, instagram, vk and other 700 sources._

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
   
   - __[Youtube Search](https://t.me/vid)__ : _Search and share YouTube links to anyone without leaving Telegram. Simply type @vid in any chat, then type your query (without hitting 'send'). This will open a panel with video suggestions. Tap on any search result to send it to your partner._
   - __[Youtube Audio Bot](https://t.me/YTAudioBot)__ : _Get YouTube videos in Audio format. This bot supports more than 20+ languages._
+  - __[Videos Craft Bot](https://t.me/VideosCraftBot)__ : _Transform any prompt into a stunning Youtube video._
   
   ### Books And Pdf Bots
   

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@
   - __[Kotatogram Desktop](https://github.com/kotatogram/kotatogram-desktop)__ : _Experimental Telegram Desktop fork._  
   - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
 
+
   ### OpenSource Bots
   
   #### OpenSource Auto Filter Bots

--- a/README.md
+++ b/README.md
@@ -276,81 +276,81 @@
 
   ## Telegram Bot Templates
 
-  ### Python
+  ### Python Bot Templates
    - __[Forden/aiogram-bot-template](https://github.com/Forden/aiogram-bot-template)__ : Scalable aiogram bot template.
    - __[AbirHasan2005/Pyrogram-Bot-Template](https://github.com/AbirHasan2005/Pyrogram-Bot-Template)__ : Pyrogram starter template.
    - __[TelegramBots/telegram.bot](https://github.com/TelegramBots/telegram.bot)__ : Simple Python bot starter.
    - __[delivrance/telegram-bot-heroku-template](https://github.com/delivrance/telegram-bot-heroku-template)__ : Heroku-ready Python Telegram bot template.
 	
-  ### JavaScript
+  ### JavaScript Bot Templates
    - __[telegraf-inline-menu/template](https://github.com/telegraf-inline-menu/template)__ : Template for bots using Telegraf.js.
    - __[yagop/node-telegram-bot-api/examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples)__ : Official node-telegram-bot-api examples.
    - __[EdJoPaTo/telegram-bot-boilerplate](https://github.com/EdJoPaTo/telegram-bot-boilerplate)__ : Boilerplate for scalable JS Telegram bots.
    - __[TediCross/TediCross](https://github.com/TediCross/TediCross)__ : Bridge template for Telegram/Discord in JS.
 	
-  ### TypeScript
+  ### TypeScript Bot Templates
    - __[grammyjs/grammY-template](https://github.com/grammyjs/grammY-template)__ : TypeScript grammY bot template.
    - __[Degreet/nestgram-template](https://github.com/Degreet/nestgram-template)__ : Nestgram starter for TS bots.
    - __[grammyjs/typescript-template](https://github.com/grammyjs/typescript-template)__ : GrammY TypeScript template with best practices.
 	
-  ### Go
+  ### Go Bot Templates
    - __[mymmrac/telego-bot-template](https://github.com/mymmrac/telego-bot-template)__ : Telego bot template.
    - __[go-telegram-bot-api/examples](https://github.com/go-telegram-bot-api/telegram-bot-api/tree/master/examples)__ : Official Go Telegram API examples.
    - __[PaulSonOfLars/gotgbot-template](https://github.com/PaulSonOfLars/gotgbot-template)__ : Gotgbot starter template.
 	
-  ### PHP
+  ### PHP Bot Templates
    - __[php-telegram-bot/example-bot](https://github.com/php-telegram-bot/example-bot)__ : Example bot with php-telegram-bot.
    - __[nutgram/nutgram-template](https://github.com/nutgram/nutgram-template)__ : Nutgram bot starter.
    - __[TelegramBot/Api](https://github.com/TelegramBot/Api)__ : PHP Telegram Bot API basic template.
 	
-  ### Java
+  ### Java Bot Templates
    - __[rubenlagus/TelegramBots ExampleBot](https://github.com/rubenlagus/TelegramBots/tree/master/TelegramBotsExample)__ : Java TelegramBots example.
    - __[pengrad/java-telegram-bot-api/examples](https://github.com/pengrad/java-telegram-bot-api/tree/master/examples)__ : Java Telegram bot API examples.
    - __[InsanusMokrassar/TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI/tree/master/examples)__ : Kotlin and Java bot API examples.
 	
-  ### Rust
+  ### Rust Bot Templates
    - __[teloxide/teloxide-template](https://github.com/teloxide/teloxide-template)__ : Teloxide bot template.
    - __[ayrat555/frankenstein/examples](https://github.com/ayrat555/frankenstein/tree/master/examples)__ : Frankenstein Rust bot examples.
 	
-  ### Kotlin
+  ### Kotlin Bot Templates
    - __[vendelieu/telegram-bot-template](https://github.com/vendelieu/telegram-bot-template)__ : Kotlin Telegram bot starter.
    - __[kotatogram/kotlin-telegram-bot-template](https://github.com/kotatogram/kotlin-telegram-bot-template)__ : Minimal Kotlin bot template.
    - __[InsanusMokrassar/TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI/tree/master/examples)__ : Kotlin Telegram bot API examples.
 	
-  ### Node.js
+  ### Node.js Bot Templates
    - __[yagop/node-telegram-bot-api/examples](https://github.com/yagop/node-telegram-bot-api/tree/master/examples)__ : Node.js Telegram bot examples.
    - __[telegraf/telegraf-template](https://github.com/telegraf/telegraf-template)__ : Telegraf.js bot starter template.
    - __[grammyjs/grammY-template](https://github.com/grammyjs/grammY-template)__ : GrammY Node.js bot template.
 	
-  ### .NET
+  ### .NET Bot Templates
    - __[TelegramBots/Telegram.Bot.Examples](https://github.com/TelegramBots/Telegram.Bot.Examples)__ : C#/.NET Telegram bot examples.
    - __[RxTelegram/RxTelegram.Bot](https://github.com/RxTelegram/RxTelegram.Bot/tree/master/examples)__ : Reactive .NET bot examples.
 	
-  ### Swift
+  ### Swift Bot Templates
    - __[rapierorg/telegram-bot-swift/Examples](https://github.com/rapierorg/telegram-bot-swift/tree/master/Examples)__ : Swift Telegram bot examples.
    - __[nerzh/telegram-vapor-bot](https://github.com/nerzh/telegram-vapor-bot/tree/main/ExampleBot)__ : Vapor Swift bot example.
 	
-  ### Scala
+  ### Scala Bot Templates
    - __[bot4s/telegram-sample-bot](https://github.com/bot4s/telegram-sample-bot)__ : Scala Telegram bot sample.
    - __[augustjune/canoe](https://github.com/augustjune/canoe/tree/master/examples)__ : Functional Scala bot examples.
 	
-  ### Ruby
+  ### Ruby Bot Templates
    - __[telegram-bot-rb/telegram-bot-starter](https://github.com/telegram-bot-rb/telegram-bot-starter)__ : Ruby bot starter.
    - __[atipugin/telegram-bot-ruby/examples](https://github.com/atipugin/telegram-bot-ruby/tree/master/examples)__ : Ruby Telegram bot API examples.
 	
-  ### C++
+  ### C++ Bot Templates
    - __[reo7sp/tgbot-cpp-examples](https://github.com/reo7sp/tgbot-cpp/tree/master/examples)__ : C++ Telegram bot examples.
    - __[egorpugin/tgbot/examples](https://github.com/egorpugin/tgbot/tree/master/examples)__ : Another C++ Telegram bot template.
 	
-  ### Elixir
+  ### Elixir Bot Templates
    - __[zhyu/nadia-example](https://github.com/zhyu/nadia-example)__ : Elixir Nadia bot example.
    - __[rockneurotiko/ex_gram/examples](https://github.com/rockneurotiko/ex_gram/tree/master/examples)__ : ExGram Elixir bot examples.
 	
-  ### Dart
+  ### Dart Bot Templates
    - __[DinoLeung/TeleDart/example](https://github.com/DinoLeung/TeleDart/tree/master/example)__ : TeleDart bot example.
    - __[TelegramBots/telebot-dart](https://github.com/TelegramBots/telebot-dart/tree/master/example)__ : Dart Telebot example.
 	
-  ### Haskell
+  ### Haskell Bot Templates
    - __[klappvisor/haskell-telegram-api/examples](https://github.com/klappvisor/haskell-telegram-api/tree/master/examples)__ : Haskell Telegram bot examples.
 
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@
   
   ### Group Manager Bots
   
+  - __[AirNope](https://t.me/airnope_bot)__ : _keeps Telegram groups clean from cryptocurrency ”airdrop” spam (and is [open-source](https://github.com/cuducos/airnope))_
   - __[Group Help](https://t.me/GroupHelpBot)__ : _This is the most complete Bot to help you manage your groups easily and safely!._
   - __[Rose](https://t.me/MissRose_bot)__ : _Powerful telegram bot to help you manage your groups._
   - __[InviteMemberBot ](https://t.me/InviteMemberBot )__ : _membership bot platform for paid Telegram channels and groups_
+
   ### Url Upload Bots
   
   - __[Video Download Bot](https://t.me/VideoDownloadBot)__ : _This Bot allows you to download videos from Facebook, Twitter, instagram, vk and other 700 sources._

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
   - __[Kotatogram Desktop](https://github.com/kotatogram/kotatogram-desktop)__ : _Experimental Telegram Desktop fork._  
   - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
 
+  - __[Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader)__ : _Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics. Supports filtering, duplicate detection, and Docker._
 
   ### OpenSource Bots
   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   </p>
   
   # Awesome Telegram
-  > A curated list of awesome things related to Telegram groups, channels, bots, apis
+  > A curated list of awesome things related to Telegram bots, apis, opensouce
   
   [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
   [![Awesome Telegram](https://cdn.jsdelivr.net/gh/kalanakt/awesome-telegram@24ddbd85dde88890615abc707517e1f2ab33b493/assets/Awesome%20Telegram.svg)](https://github.com/kalanakt/awesome-telegram)
@@ -14,7 +14,7 @@
   
   Please take a quick gander at the [contribution guidelines](https://github.com/kalanakt/awesome-telegram/blob/main/Contributing.md) first. Thanks to all [contributors](https://github.com/kalanakt/awesome-telegram/graphs/contributors); you rock!
   
-  > _You'r P.R. is welcome add your telegram group/ channel/ bot And apis And also If you see a content here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you!_
+  > _You'r P.R. is welcome add your telegram bot And apis And also If you see a content here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you!_
   
   Add Awesome Telegram Batch 
   
@@ -34,30 +34,6 @@
     - [About](#about)
     
     - [Apps](#apps)
-    
-    - [Telegram Groups](#telegram-groups)
-      - [Art And Design Groups](#art-and-design-groups)
-      - [Book And Magazine Groups](#book-and-magazine-groups)
-      - [Chat Groups](#chat-groups)
-      - [Cryptocurrency Groups](#cryptocurrency-groups)
-      - [Education Groups](#education-groups)
-      - [Games And Apps Groups](#games-and-apps-groups)
-      - [Movies And Tv Series Groups](#movies-and-tv-series-groups)
-      - [Music Groups](#music-groups)
-      - [Technology Groups](#technology-groups)
-      - [Other Groups](#other-groups)
-    
-    - [Telegram Channels](#telegram-channels)
-      - [Art And Design Channels](#art-and-design-channels)
-      - [Book And Magazine Channels](#book-and-magazine-channels)
-      - [Cryptocurrency Channels](#cryptocurrency-channels)
-      - [Education Channels](#education-channels)
-      - [Entertainment Channels](#entertainment-channels)
-      - [Games And Apps Channels](#games-and-apps-channels)
-      - [Movies And Tv Series Channels](#movies-and-tv-series-channels)
-      - [Music Channels](#music-channels)
-      - [Technology Channels](#technology-channels)
-      - [Other Channels](#other-channels)
       
     - [Telegram Bots](#telegram-bots)
       - [Music Bots](#music-bots)
@@ -137,117 +113,6 @@
       </td>
     </tr>
   </table>
-  
-  ## Telegram Groups
-  
-  
-  ### Art And Design Groups
-  
-  - __[Art Plays](https://t.me/artplays_art)__ : _A channel about art, paintings, drawing lessons and creative people._
-  - __[Art](https://t.me/art_exposition)__ : _Art in your pocket_
-  
-  
-  ### Book And Magazine Groups
-  
-  - __[Crime Stories ️](https://t.me/crimestoryy)__ : _Interesting crime stories you won't find anywhere else on telegram._
-  - __[Engineering Books](https://t.me/embedded_library)__ : _The best books about engineering. Mechanics, electronics, mathematics, programming and much more! Subscribe to get free books every week!_
-  
-  
-  ### Chat Groups
-  
-  - __[FRIENDS](https://telegram.me/NewFriendChat)__ : _Find your new friend, All countries, all nation._
-  - __[Fun chatting group](https://telegram.me/English_Fun_Group)__ : _Fun chatting group._
-  
-  ### Cryptocurrency Groups
-  
-  - __[Crypto.com Trading Signals](https://t.me/cryptocom_tradingsignals)__ : _This is the Crypto.com official community, creator of the fastest growing crypto ecosystem! We offer high Quality Signals for BINANCE, BYBIT, BITTREX, etc._
-  - __[Nfts / Metaverse & More](https://t.me/defi_trading_nfts_metaverse)__ : _A Latest News, alerts & NFT's. Follow to know the Top Coins of 2022_
-  
-  ### Education Groups
-  
-  - __[Data Science, ML &AI Nugget Chats](https://t.me/DatascienceChats)__ : _Discussion community for DS, ML, IOT, AI, DEEP LEARNING amd much more.._
-  - __[C/C++](https://t.me/programminginc)__ : _International telegram group of C/C++ programming._
-  
-  ### Games And Apps Groups
-  
-  - __[Jugad PUBG Chat Group](https://t.me/jugadpubggrp)__ : _Jugad PUBG Chat Group._
-  - __[PC Games Support](https://t.me/pc_game_down_support)__ : _Best Telegram group to discuss on PC games._
-  
-  ### Movies And Tv Series Groups
-  
-  - __[Spacious Universe](https://t.me/spaciousuniversegroup1)__ : _A Group Cinema Lovers_
-  - __[Anime Chat](https://t.me/Anime_Chat_Group_ACG)__ : _A group that is made for discussion purposes dedicated to anime community._
-  - __[Filmykeedha](https://t.me/+oheEij7NzSExZjQ1)__ : _A Group for all types Movies and Webseries Search_
-  ### Music Groups
-  
-  - __[Spotify Group](https://t.me/SpotifyGroup)__ : _Chat group to discuss about music and to request others for music or link_
-  - __[Music Land](https://t.me/tgMusicland)__ : _New and old Album, movies and devotional songs in all languages._
-  
-  ### Technology Groups
-  
-  - __[Python](https://t.me/python)__ : _Telegram public chat room for discussion about the Python programming language._
-  - __[Telegram Android Talk](https://t.me/TelegramAndroidTalk)__ : _Telegram chat group to talk about android._
-  
-  ### Other Groups
-  
-  - __[Spiritual Group](https://t.me/SpiritualGroup)__ : _It is a forum for spiritual seekers to discuss the philosophical and spiritual wisdom of Sanatana Dharma._
-  
-  
-  
-  ## Telegram Channels
-  
-
-  ### Art And Design Channels
-  
-  - __[WALLPAPER](https://t.me/bestwallpapes)__ : _Best channel on Telegram to download HD wallpapers._
-  - __[Private Art](https://t.me/privateart)__ : _Channel to find best painting in the world._
-  - __[Shutterstock Adobestock Free Download](https://t.me/gfxload)__ : _Free Download Adobestock and Shutterstock premium stock photos, vectors and images._
-  
-  ### Book And Magazine Channels
-  
-  - __[Engineering E-Books ™](https://t.me/Engineering_Ebooks1)__ : _You will get all Engineering branches E-Books , Articles , Exam Related Books Etc._
-  - __[EBooks & Magazines](https://t.me/English_Hindi_Novels_Magazine)__ : _Best English EBooks and magazine in PDF format for all._
-  
-  ### Cryptocurrency Channels
-  
-  - __[Crypto Miami](https://t.me/crypto_miami)__ : _Latest Cryptocurrency and Blockhchain news._
-  - __[Bitcoin Industry](https://t.me/bitcoin_industry)__ : _Publishing news from the crypto industry faster than anyone else_
-  
-  ### Education Channels
-  
-  - __[Did You Know](https://t.me/Didyoureallyknow)__ : _Join this channel to learn something new everyday._
-  - __[The Front End](https://t.me/thefrontend)__ : _News, Articles, Tutorials, UI/UX thoughts on front end. mobile and web dev._
-  - 
-  ### Entertainment Channels
-  
-  - __[Epic Memes and Jokes](https://t.me/DailyEpicMemes)__ : _Meme hub. Follow for best sarcastic jokes, Memes, GIFs and much more_
-  - __[Memes](https://t.me/bestmemes)__ : _Best channel for jokes and Memes. They post regularly and they totally worth it!._
-  
-  ### Games And Apps Channels
-  
-  - __[Clash Of Clans Official](https://t.me/ClashOfClans)__ : _Official clash of clan telegram channel. Join to get quick update on your favorite game.._
-  - __[AndroGamer](https://t.me/AndroGamer)__ : _AndroGaмєr - The Dreamland of mods and Tricks!!_
-  
-  ### Movies And Tv Series Channels
-  
-  - __[Ensemble](https://t.me/ensembly)__ : _Spreading happiness one show at a time._
-  - __[Ongoing Series Channel](https://t.me/Ongoing_Series_Channel)__ : _A channel for onging tv serieses_
-  
-  ### Music Channels
-  
-  - __[Selena Gomez](https://t.me/Selena_FanClub)__ : _Selena Gomez Fan club. Join for Music, photos, live performance, ReMix, Events, TVShows, Interview, Wallpaper and more._
-  - __[English songs and lyrics](https://t.me/Songs_Lyrics_in_English)__ : _Get English Lyrics for any songs._
-  
-
-  ### Technology Channels
-  
-  - __[Programming Tips](https://t.me/ProgrammingTip)__ : _Useful channel if you are a programmer. Join for Programming tips, design pattern, software principle._
-  - __[Telegram Tips](https://t.me/TelegramTips)__ : _Telegram has tons of feature. This official channel from Telegram show how to use the features._
-  
-  ### Other Channels
-  
-  - __[Science](https://t.me/science)__ : _Best channel on Telegram to get science related articles and videos._
-  
   
   ## Telegram Bots
   

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
   
   - __[Group Help](https://t.me/GroupHelpBot)__ : _This is the most complete Bot to help you manage your groups easily and safely!._
   - __[Rose](https://t.me/MissRose_bot)__ : _Powerful telegram bot to help you manage your groups._
-  
+   __[InviteMemberBot ](https://t.me/InviteMemberBot )__ : _membership bot platform for paid Telegram channels and groups_
   ### Url Upload Bots
   
   - __[Video Download Bot](https://t.me/VideoDownloadBot)__ : _This Bot allows you to download videos from Facebook, Twitter, instagram, vk and other 700 sources._
@@ -173,7 +173,7 @@
   
   - __[Wikipedia Search](https://t.me/wiki)__ : _Search for wiki article in any chats or groups, no need to add it anywhere. Simply type @wiki in any chat, then type your query (without hitting 'send'). Bot will open a panel with Wikipedia article suggestions. Tap on an item to send it to your chat partner right away._
   - __[Livegram Bot](https://t.me/LivegramBot)__ : _Livegram Bot is a builder of feedback bots for Telegram. This can be used to broadcast messages, get feedback messages in groups, get bot statistics and more._
-  
+ - __[SUCH](https://t.me/such)__ : _feedback and support bot builder for channel admins, bot developers, business owners, and community managers._
   
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
         - [OpenSource Chat Bots](#opensource-chat-bots)
         - [OpenSource Group Manager Bots](#opensource-group-manager-bots)
         - [OpenSource User Bots](#opensource-user-bots)
+        - [OpenSource Anonymous Group Chat Bots](#opensource-anonymous-group-chat-bots)
         - [OpenSource Download Bots](#opensource-download-bots)
         - [OpenSource Youtube Bots](#opensource-youtube-bots)
         - [OpenSource File Store](#opensource-file-store-bots)
@@ -203,7 +204,7 @@
   #### OpenSource Filter Bots
   - __[Unlimited Filter Bot](https://github.com/TroJanzHEX/Unlimited-Filter-Bot)__ By [TroJanzHEX](https://github.com/TroJanzHEX): _An advanced Filter Bot with nearly unlimited filters!_
   - __[Filter Bot](https://github.com/Jijinr/Filter-Bot)__ By [Jijinr](https://github.com/Jijinr)
-  
+    
   #### OpenSource Group Manager Bots
   - __[Amelia Group Bot](https://github.com/xAbhish3k/AmeliaRobot)__ : _An Anime Theme Telegram group management bot. With lot of features._
   - __[Alita Robot](https://github.com/DivideProjects/Alita_Robot)__ : _Alita is a Telegram Group management bot made using Pyrogram and Python, which makes it modern and faster than most of the Telegram chat managers._
@@ -217,6 +218,10 @@
   - __[Ridogram](https://github.com/iniridwanul/Ridogram)__ : _https://github.com/iniridwanul/Ridogram_
   - __[Userge](https://github.com/UsergeTeam/Userge)__ : _Pluggable Telegram UserBot_
   - __[Ultroid](https://github.com/TeamUltroid/Ultroid)__ : _Advanced Multi-Featured Telegram UserBot, Built in Python Using Telethon lib._
+
+  #### OpenSource Anonymous Group Chat Bots
+  - __[Private Parlor XT](https://github.com/Private-Parlor/Private-Parlor-XT)__ : _A featureful Telegram bot for making anonymous group chats_
+  - __[secretlounge-ng](https://github.com/secretlounge/secretlounge-ng)__ : _A bot to make an anonymous group chat on Telegram_
 
   #### OpenSource Download Bots
   - __[Youtube Dl bot](https://github.com/aryanvikash/Youtube-Downloader-Bot)__

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@
   #### OpenSource Filter Bots
   - __[Unlimited Filter Bot](https://github.com/TroJanzHEX/Unlimited-Filter-Bot)__ By [TroJanzHEX](https://github.com/TroJanzHEX): _An advanced Filter Bot with nearly unlimited filters!_
   - __[Filter Bot](https://github.com/Jijinr/Filter-Bot)__ By [Jijinr](https://github.com/Jijinr)
-    
+  
   #### OpenSource Group Manager Bots
   - __[Amelia Group Bot](https://github.com/xAbhish3k/AmeliaRobot)__ : _An Anime Theme Telegram group management bot. With lot of features._
   - __[Alita Robot](https://github.com/DivideProjects/Alita_Robot)__ : _Alita is a Telegram Group management bot made using Pyrogram and Python, which makes it modern and faster than most of the Telegram chat managers._

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
   #### OpenSource Anonymous Group Chat Bots
   - __[Private Parlor XT](https://github.com/Private-Parlor/Private-Parlor-XT)__ : _A featureful Telegram bot for making anonymous group chats_
   - __[secretlounge-ng](https://github.com/secretlounge/secretlounge-ng)__ : _A bot to make an anonymous group chat on Telegram_
+  - __[librelounge](https://github.com/usadev1984/librelounge)__ : _This project is a soft fork of secretlounge-ng that aims to track and merge most changes that are added to it while adding some essential features from the no-longer-updated [catlounge](https://github.com/catlounge/catlounge)_
 
   #### OpenSource Download Bots
   - __[Youtube Dl bot](https://github.com/aryanvikash/Youtube-Downloader-Bot)__

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
    - __[AbirHasan2005/Pyrogram-Bot-Template](https://github.com/AbirHasan2005/Pyrogram-Bot-Template)__ : Pyrogram starter template.
    - __[TelegramBots/telegram.bot](https://github.com/TelegramBots/telegram.bot)__ : Simple Python bot starter.
    - __[delivrance/telegram-bot-heroku-template](https://github.com/delivrance/telegram-bot-heroku-template)__ : Heroku-ready Python Telegram bot template.
+- [TeleGet](https://github.com/xwc9527/TeleGet) - High-speed Telegram file downloader SDK with multi-connection parallel downloading.
 	
   ### JavaScript Bot Templates
    - __[telegraf-inline-menu/template](https://github.com/telegraf-inline-menu/template)__ : Template for bots using Telegraf.js.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
      
     - [OpenSource](#opensource)
       - [OpenSource Apps](#opensource-apps)
+        - [Official Apps](#official-apps)
+        - [Unofficial Apps](#unofficial-apps)
       - [OpenSource Bots](#opensource-bots)
         - [OpenSource Auto Filter Bots](#opensource-auto-filter-bots)
         - [OpenSource Filter Bots](#opensource-filter-bots)
@@ -176,6 +178,8 @@
   ## OpenSource
   
   ### OpenSource Apps
+  
+  #### Official Apps
   - __[Telegram Database Library](https://github.com/tdlib/td)__ : _Cross-platform library for building custom Telegram apps, see [TDLib](https://core.telegram.org/tdlib) for details._
   - __[Telegram for Android](https://github.com/DrKLO/Telegram)__ : _Official Android App, see [Google Play Market page](https://telegram.org/dl/android) for full description._
   - __[Telegram for iOS](https://github.com/TelegramMessenger/Telegram-iOS)__ 
@@ -186,14 +190,21 @@
   - __[Telegram React](https://github.com/evgeny-nadymov/telegram-react)__ : _JavaScript client for browsers. Mac, Windows, Linux._
   - __[Telegram Desktop](https://github.com/telegramdesktop/tdesktop)__ : _Qt-based desktop client. Mac, Windows, Linux._
   - __[Telegram for WP](https://github.com/evgeny-nadymov/telegram-wp)__ : _Telegram Messenger for Windows Phone_
-  - __[Telegram X](https://github.com/TGX-Android/Telegram-X)__ : _Official alternative Telegram client for Android._
-  - __[Telegram CLI](https://github.com/vysheng/tg)__ : _Linux Command-line interface for Telegram._
-  - __[Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS)__ : _FOSS-friendly fork of the original Telegram client for Android._
-  - __[NekoX](https://github.com/NekoX-Dev/NekoX)__ : _Third-party Telegram client, based on Telegram-FOSS with features added._
-  - __[Unigram ](https://github.com/UnigramDev/Unigram)__ : _A Telegram client optimized for Windows 10 (desktop and Xbox One)._
-  - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
-  - __[Plus Messenger](https://github.com/rafalense/Plus-Messenger)__ : _Unofficial Android client that uses Telegram's API._
+  - __[Telegram X for Android](https://github.com/TGX-Android/Telegram-X)__ : _Official alternative Telegram client for Android._
 
+  #### Unofficial Apps
+  - __[Telegram CLI](https://github.com/vysheng/tg)__ : _Linux Command-line interface for Telegram._
+  - __[Telegram FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS)__ : _FOSS-friendly fork of the original Telegram client for Android._
+  - __[Forkgram Android](https://github.com/forkgram/TelegramAndroid)__ : _Fork client of Telegram app for Android._
+  - __[Forkgram Desktop](https://github.com/forkgram/tdesktop)__ : _Fork of Telegram Desktop messaging app._
+  - __[Nekogram](https://github.com/Nekogram/Nekogram)__ : _Open-source third-party Telegram client with few but useful mods._
+  - __[NekoX](https://github.com/NekoX-Dev/NekoX)__ : _Third-party Telegram client, based on Telegram-FOSS with features added._
+  - __[Nicegram Android](https://github.com/nicegram/Nicegram-Android)__ : _Telegram API-based messenger that offers enhanced opportunities for business and personal communication alike._
+  - __[Nicegram iOS](https://github.com/nicegram/Nicegram-iOS)__ : _Telegram API-based messenger that offers enhanced opportunities for business and personal communication alike._  
+  - __[Plus Messenger](https://github.com/rafalense/Plus-Messenger)__ : _Unofficial Android client that uses Telegram's API._
+  - __[Unigram ](https://github.com/UnigramDev/Unigram)__ : _A Telegram client optimized for Windows 10 (desktop and Xbox One)._
+  - __[Kotatogram Desktop](https://github.com/kotatogram/kotatogram-desktop)__ : _Experimental Telegram Desktop fork._  
+  - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
 
   ### OpenSource Bots
   

--- a/README.md
+++ b/README.md
@@ -186,9 +186,13 @@
   - __[Telegram React](https://github.com/evgeny-nadymov/telegram-react)__ : _JavaScript client for browsers. Mac, Windows, Linux._
   - __[Telegram Desktop](https://github.com/telegramdesktop/tdesktop)__ : _Qt-based desktop client. Mac, Windows, Linux._
   - __[Telegram for WP](https://github.com/evgeny-nadymov/telegram-wp)__ : _Telegram Messenger for Windows Phone_
+  - __[Telegram X](https://github.com/TGX-Android/Telegram-X)__ : _Official alternative Telegram client for Android._
   - __[Telegram CLI](https://github.com/vysheng/tg)__ : _Linux Command-line interface for Telegram._
+  - __[Telegram-FOSS](https://github.com/Telegram-FOSS-Team/Telegram-FOSS)__ : _FOSS-friendly fork of the original Telegram client for Android._
+  - __[NekoX](https://github.com/NekoX-Dev/NekoX)__ : _Third-party Telegram client, based on Telegram-FOSS with features added._
   - __[Unigram ](https://github.com/UnigramDev/Unigram)__ : _A Telegram client optimized for Windows 10 (desktop and Xbox One)._
   - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
+  - __[Plus Messenger](https://github.com/rafalense/Plus-Messenger)__ : _Unofficial Android client that uses Telegram's API._
 
 
   ### OpenSource Bots

--- a/README.md
+++ b/README.md
@@ -193,16 +193,16 @@
   ### OpenSource Bots
   
   #### OpenSource Auto Filter Bots
-  - __[Adv Auto Filter Bot](https://github.com/CrazyBotsz/Adv-Auto-Filter-Bot)__ : _A Advanced Auto Filter Bot Which Can Be Used In Many Groups With Multiple Channel Support.._
-  - __[Adv Auto Filter Bot V2](https://github.com/CrazyBotsz/Adv-Auto-Filter-Bot-V2)__ : _An advance automatic filter bot for filtering files and media in a telegram chat._
-  - __[Auto Filter Bot V2](https://github.com/TroJanzHEX/Auto-Filter-Bot-V2)__
+  - __[Adv Auto Filter Bot](https://github.com/CrazyBotsz/Adv-Auto-Filter-Bot)__ By [CrazyBotsz](https://github.com/CrazyBotsz/)  : _A Advanced Auto Filter Bot Which Can Be Used In Many Groups With Multiple Channel Support.._
+  - __[Adv Auto Filter Bot V2](https://github.com/CrazyBotsz/Adv-Auto-Filter-Bot-V2)__ By [CrazyBotsz](https://github.com/CrazyBotsz/)  : _An advance automatic filter bot for filtering files and media in a telegram chat._
+  - __[Auto Filter Bot V2](https://github.com/TroJanzHEX/Auto-Filter-Bot-V2)__ By [TroJanzHEX](https://github.com/TroJanzHEX)  
   
-  - __[IMDb Auto Filter Bot](https://github.com/kalanakt/IMDb-Auto-Filter-Bot)__ : _Auto-filter Bot With IMDb Poster._
-  - __[Eva Maria Editors' Choice](https://github.com/kalanakt/EvaMaria_Editors_Choice)__ : _Editors' Choice of Eva Maria Telegram Bot_
+  - __[IMDb Auto Filter Bot](https://github.com/kalanakt/IMDb-Auto-Filter-Bot)__ By [kalanakt](https://github.com/kalanakt)  : _Auto-filter Bot With IMDb Poster._
+  - __[Eva Maria Editors' Choice](https://github.com/kalanakt/EvaMaria_Editors_Choice)__ By [kalanakt](https://github.com/kalanakt)  : _Editors' Choice of Eva Maria Telegram Bot_
   
   #### OpenSource Filter Bots
-  - __[Unlimited Filter Bot](https://github.com/TroJanzHEX/Unlimited-Filter-Bot)__ : _An advanced Filter Bot with nearly unlimited filters!_
-  - __[Filter Bot](https://github.com/Jijinr/Filter-Bot)__
+  - __[Unlimited Filter Bot](https://github.com/TroJanzHEX/Unlimited-Filter-Bot)__ By [TroJanzHEX](https://github.com/TroJanzHEX): _An advanced Filter Bot with nearly unlimited filters!_
+  - __[Filter Bot](https://github.com/Jijinr/Filter-Bot)__ By [Jijinr](https://github.com/Jijinr)
   
   #### OpenSource Group Manager Bots
   - __[Amelia Group Bot](https://github.com/xAbhish3k/AmeliaRobot)__ : _An Anime Theme Telegram group management bot. With lot of features._
@@ -229,13 +229,13 @@
   - __[FileStore Bot](https://github.com/avipatilpro/FileStoreBot)__ : _Telegram Files Store Bot with Permeant Sharable Links by [@avipatilpro](https://github.com/avipatilpro)._
 
   #### OpenSource Music Bots
-  - __[Remix](https://github.com/callsmusic/remix)__ : _Powerful Telegram music bot._
-  - __[MusicPlayer](https://github.com/subinps/MusicPlayer)__ : _Telegram Bot to play music in VoiceChat with Channel Support and autostarts Radio._
-  - __[YukkiMusic Bot](https://github.com/TeamYukki/YukkiMusicBot)__ : _Telegram Group Calls Streaming bot with some useful features, written in Python with Pyrogram and Py-Tgcalls. Supporting platforms like Youtube, Spotify, Resso, AppleMusic, Soundcloud and M3u8 Links._
+  - __[Remix](https://github.com/callsmusic/remix)__ By [callsmusic](https://github.com/callsmusic) : _Powerful Telegram music bot._
+  - __[MusicPlayer](https://github.com/subinps/MusicPlayer)__ By [subinps](https://github.com/subinps) : _Telegram Bot to play music in VoiceChat with Channel Support and autostarts Radio._
+  - __[YukkiMusic Bot](https://github.com/TeamYukki/YukkiMusicBot)__ By [TeamYukki](https://github.com/TeamYukki) : _Telegram Group Calls Streaming bot with some useful features, written in Python with Pyrogram and Py-Tgcalls. Supporting platforms like Youtube, Spotify, Resso, AppleMusic, Soundcloud and M3u8 Links._
 
   #### OpenSource Other Bots
-  - __[freqtrade](https://github.com/freqtrade/freqtrade)__ : _Free, open source crypto trading bot_
-  - __[rss bot](https://github.com/iovxw/rssbot)__ : _Lightweight Telegram RSS notification bot._
+  - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
+  - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
 
 
   ## Telegram Libraries

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@
   
   - __[AIOGram](https://github.com/aiogram/aiogram)__ : _A pretty simple and fully asynchronous library for Telegram Bot API written with asyncio and aiohttp.._ 
   - __[Pyrogram](https://github.com/pyrogram/pyrogram)__ : _Elegant, modern and asynchronous Telegram MTProto API framework in Python for users and bots._
+  - __[EzTg](https://github.com/hexyedev/eztg)__ : _A simple and asynchronous telegram api wrapper based on the official Telegram Bot API._ 
   
 
   ### Rust

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@
 
   #### OpenSource Other Bots
   - __[AiogramShopBot](https://github.com/ilyarolf/AiogramShopBot)__  By [Ilyarolf](https://github.com/ilyarolf) : _Open-source Telegram shop bot built with Aiogram 3, supporting digital and physical product sales, cryptocurrency payments (BTC, ETH, LTC, SOL, BNB, USDT), referral system and web admin panel._
+  - __[Broletter](https://github.com/landigf/Broletter)__  By [landigf](https://github.com/landigf) : _Personalized daily science briefing bot — reads arXiv every night, explains papers via Gemini, and delivers a tap-to-expand preview card so users only read what interests them. Supports Telegram Stars subscriptions._
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
   - __[Group Help](https://t.me/GroupHelpBot)__ : _This is the most complete Bot to help you manage your groups easily and safely!._
   - __[Rose](https://t.me/MissRose_bot)__ : _Powerful telegram bot to help you manage your groups._
   - __[InviteMemberBot ](https://t.me/InviteMemberBot )__ : _membership bot platform for paid Telegram channels and groups_
+  - __[OmniGest](https://t.me/OmniGest_bot)__ : _Free all-in-one group management bot with anti-spam, captcha, AI moderation, custom commands, welcome messages, and a web dashboard._
 
   ### Url Upload Bots
   

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@
   
   - __[A Cute Bot](https://t.me/acutebot)__ : _This bot can help you to get information about your favorite Anime, Manga, Movies, TVshows and lot of other related stuffs!._
   - __[Bae Suzy](https://t.me/SpaciousUniversBot)__ : _Bot For Movies And Tv series Filter/ Store .._
+- __[Shoof Aflam](https://t.me/shoof_aflam_bot)__ : _Search where to watch 14,000+ Arabic movies and series across 18 streaming platforms. Returns poster, rating, and direct links._
   
   ### Subtitle Bots
   

--- a/README.md
+++ b/README.md
@@ -183,10 +183,11 @@
   
   ### Other Bots
   
-  - __[Wikipedia Search](https://t.me/wiki)__ : _Search for wiki article in any chats or groups, no need to add it anywhere. Simply type @wiki in any chat, then type your query (without hitting 'send'). Bot will open a panel with Wikipedia article suggestions. Tap on an item to send it to your chat partner right away._
-  - __[Livegram Bot](https://t.me/LivegramBot)__ : _Livegram Bot is a builder of feedback bots for Telegram. This can be used to broadcast messages, get feedback messages in groups, get bot statistics and more._
+ - __[Wikipedia Search](https://t.me/wiki)__ : _Search for wiki article in any chats or groups, no need to add it anywhere. Simply type @wiki in any chat, then type your query (without hitting 'send'). Bot will open a panel with Wikipedia article suggestions. Tap on an item to send it to your chat partner right away._
+ - __[Livegram Bot](https://t.me/LivegramBot)__ : _Livegram Bot is a builder of feedback bots for Telegram. This can be used to broadcast messages, get feedback messages in groups, get bot statistics and more._
  - __[SUCH](https://t.me/such)__ : _feedback and support bot builder for channel admins, bot developers, business owners, and community managers._
  - __[Code Stars](https://t.me/code_stars)__ : _Code Stars highlights the most popular GitHub repos from the last hour, helping you discover innovative projects early._
+ - __[Assignment Writer](https://t.me/MasterAssignmentBot)__ : _Assignment writer bot can write your assignments on different papers with handwritten fonts and colours withing seconds._
   
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@
   - __[YukkiMusic Bot](https://github.com/TeamYukki/YukkiMusicBot)__ By [TeamYukki](https://github.com/TeamYukki) : _Telegram Group Calls Streaming bot with some useful features, written in Python with Pyrogram and Py-Tgcalls. Supporting platforms like Youtube, Spotify, Resso, AppleMusic, Soundcloud and M3u8 Links._
 
   #### OpenSource Other Bots
+  - __[AiogramShopBot](https://github.com/ilyarolf/AiogramShopBot)__  By [Ilyarolf](https://github.com/ilyarolf) : _Open-source Telegram shop bot built with Aiogram 3, supporting digital and physical product sales, cryptocurrency payments (BTC, ETH, LTC, SOL, BNB, USDT), referral system and web admin panel._
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@
  - __[Livegram Bot](https://t.me/LivegramBot)__ : _Livegram Bot is a builder of feedback bots for Telegram. This can be used to broadcast messages, get feedback messages in groups, get bot statistics and more._
  - __[SUCH](https://t.me/such)__ : _feedback and support bot builder for channel admins, bot developers, business owners, and community managers._
  - __[Code Stars](https://t.me/code_stars)__ : _Code Stars highlights the most popular GitHub repos from the last hour, helping you discover innovative projects early._
- - __[Assignment Writer](https://t.me/MasterAssignmentBot)__ : _Assignment writer bot can write your assignments on different papers with handwritten fonts and colours withing seconds._
+ - __[Assignment Writer](https://t.me/MasterAssignmentBot)__ : _Assignment writer bot can write your assignments on different papers with handwritten fonts and colours within seconds._
   
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
   - __[Kotatogram Desktop](https://github.com/kotatogram/kotatogram-desktop)__ : _Experimental Telegram Desktop fork._  
   - __[MadelineProto ](https://github.com/danog/MadelineProto)__ : _A PHP MTProto Telegram client._
 
+  - __[Telegram Archive](https://github.com/GeiserX/Telegram-Archive)__ : _Automated Telegram backup with Docker. Performs incremental backups of messages and media with a web viewer, real-time listener, and push notifications._
   - __[Telegram Media Downloader](https://github.com/rfsbraz/telegram-downloader)__ : _Self-hosted daemon that automatically downloads media from Telegram channels, groups, and forum topics. Supports filtering, duplicate detection, and Docker._
 
   ### OpenSource Bots


### PR DESCRIPTION
Adds [Broletter](https://github.com/landigf/Broletter) to the **OpenSource Other Bots** section.

It's a personalized daily science briefing bot built by an MSc CS student at ETH Zürich:
- Reads fresh arXiv papers every night across user-configured categories
- Uses Gemini to explain papers conversationally
- Delivers a tap-to-expand preview card (no wall of text)
- Supports Telegram Stars subscriptions
- Open source (MIT), Python + FastAPI

Entry kept alphabetical within the section.