### PR TITLE
Add DeepAlpha Bot - AI Crypto Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@
  - __[Assignment Writer](https://t.me/MasterAssignmentBot)__ : _Assignment writer bot can write your assignments on different papers with handwritten fonts and colours within seconds._
   - __[Cyber Collector](https://t.me/cybercollectorbot)__ : _Download videos from TikTok (no watermark), Instagram Reels/Stories, YouTube Shorts, X/Twitter and Facebook. No signup required._
   
+ - __[DeepAlpha Bot](https://t.me/DeepAlphaVault_bot)__ : _AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)_
+
   ## OpenSource
   
   ### OpenSource Apps


### PR DESCRIPTION
## Adding DeepAlpha Bot (@DeepAlphaVault_bot)

AI-powered crypto trading bot manageable entirely from Telegram:

- **3 bot types**: AI Bot, Grid Bot, DCA Bot
- **12 exchanges**: Bybit, Binance, OKX, MEXC, BingX, HTX & more
- **Commands**: /status, /start_bot, /stop_bot, /balance, /pnl, /trades
- **Non-custodial**: funds stay on user's exchange
- **Free 7-day trial**

Telegram: https://t.me/DeepAlphaVault_bot
Website: https://deepalphabot.com
GitHub: https://github.com/stefanoviana/deepalpha

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DeepAlpha Bot to the available bots listing, featuring AI-powered crypto trading with AI/Grid/DCA management capabilities across multiple exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->