### PR TITLE
Add CoinPing to Other Bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@
  - __[Assignment Writer](https://t.me/MasterAssignmentBot)__ : _Assignment writer bot can write your assignments on different papers with handwritten fonts and colours within seconds._
   - __[Cyber Collector](https://t.me/cybercollectorbot)__ : _Download videos from TikTok (no watermark), Instagram Reels/Stories, YouTube Shorts, X/Twitter and Facebook. No signup required._
  - __[DeepAlpha Bot](https://t.me/DeepAlphaVault_bot)__ : _AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)_
-  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
+ - __[CoinPing](https://t.me/CoinPingAlertBot)__ : _Multi-condition crypto price alerts via Telegram: price thresholds, 24h % change, and cross-exchange spreads. [Open Source](https://github.com/SeigeC/coinping-bot). Free tier: 3 alerts._
+ - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
 
   ## OpenSource
   


### PR DESCRIPTION
Add CoinPing — multi-condition crypto price alerts bot on Telegram

https://t.me/CoinPingAlertBot | https://github.com/SeigeC/coinping-bot

🤖 Generated with Neo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “CoinPing” bot entry to the Telegram Bots list in the README.
  * Updated the order of the bot list so the existing “Account Created Date” entry now appears after the new addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->