### PR TITLE
Add Weight Goal Bot to OpenSource Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
-  - __[Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot)__  By [IgorShadurin](https://github.com/IgorShadurin) : _Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements._
+  - __[Weight Goal Bot](https://t.me/my_weight_goal_bot)__  By [IgorShadurin](https://github.com/IgorShadurin) : _Open-source group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [Source](https://github.com/IgorShadurin/weight-telegram-bot)._
 
 
   ## Telegram Bot Templates

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
-  - __[Weight Goal Bot](https://t.me/my_weight_goal_bot)__  By [IgorShadurin](https://github.com/IgorShadurin) : _Open-source group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [Source](https://github.com/IgorShadurin/weight-telegram-bot)._
+  - __[Weight Goal Bot](https://t.me/my_weight_goal_bot)__  By [IgorShadurin](https://github.com/IgorShadurin) : _Apache-2.0 open-source group bot for photo-backed weekly weight goals, charts, reminders, and 53 achievements in nine languages. [Source](https://github.com/IgorShadurin/weight-telegram-bot)._
 
 
   ## Telegram Bot Templates

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@
   - __[English Wikipedia Link Converter](https://github.com/jnton/english-wikipedia-link-converter-telegram-bot)__  By [JnTon](https://github.com/jnton) : _Telegram bot that converts any non-English Wikipedia link into its English equivalent_
   - __[freqtrade](https://github.com/freqtrade/freqtrade)__  By [freqtrade](https://github.com/freqtrade) : _Free, open source crypto trading bot_
   - __[rss bot](https://github.com/iovxw/rssbot)__  By [iovxw](https://github.com/iovxw) : _Lightweight Telegram RSS notification bot._
+  - __[Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot)__  By [IgorShadurin](https://github.com/IgorShadurin) : _Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements._
 
 
   ## Telegram Bot Templates


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) ([source](https://github.com/IgorShadurin/weight-telegram-bot)) to OpenSource Other Bots.

I maintain this Apache-2.0-licensed Telegram group bot. Its complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian; it uses photo-backed weigh-ins and provides weekly checkpoints, progress charts, reminders, and 53 achievements.

## Verification

- [x] The [live bot](https://t.me/my_weight_goal_bot) link resolves.
- [x] The [source repository](https://github.com/IgorShadurin/weight-telegram-bot) is public and licensed under Apache-2.0.
- [x] I searched this repository for an existing duplicate.
- [x] This change follows the existing source-project format and alphabetical placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the “Weight Goal Bot” to the Telegram Bots listing, including its GitHub link and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->