### PR TITLE
Add CrawlbenchAlertsBot to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@
  - __[CoinPing](https://t.me/CoinPingAlertBot)__ : _Multi-condition crypto price alerts via Telegram: price thresholds, 24h % change, and cross-exchange spreads. [Open Source](https://github.com/SeigeC/coinping-bot). Free tier: 3 alerts._
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
 
+ - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Facebook Marketplace monitoring alerts for flippers and sourcing teams. Link your Crawlbench account to get match pings on Telegram. [Website](https://crawlbench.com/?utm_source=github&utm_medium=awesome_list&utm_campaign=kalanakt-awesome-telegram&utm_content=pr)_
+
   ## OpenSource
   
   ### OpenSource Apps

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@
  - __[CoinPing](https://t.me/CoinPingAlertBot)__ : _Multi-condition crypto price alerts via Telegram: price thresholds, 24h % change, and cross-exchange spreads. [Open Source](https://github.com/SeigeC/coinping-bot). Free tier: 3 alerts._
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
 
- - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Facebook Marketplace monitoring alerts for flippers and sourcing teams. Link your Crawlbench account to get match pings on Telegram. [Website](https://crawlbench.com/?utm_source=github&utm_medium=awesome_list&utm_campaign=kalanakt-awesome-telegram&utm_content=pr)_
+  - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
 
   ## OpenSource
   


### PR DESCRIPTION
Adds [Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot) under **Other Bots**.

Telegram alert bot for [Crawlbench](https://crawlbench.com/?utm_source=github&utm_medium=awesome_list&utm_campaign=kalanakt-awesome-telegram&utm_content=pr) Facebook Marketplace monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the “Crawlbench Alerts” Telegram bot to the “Other Bots” list, including its link and description (account linking and website URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->