### PR TITLE
Add Mitup To Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
  - __[DeepAlpha Bot](https://t.me/DeepAlphaVault_bot)__ : _AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)_
  - __[CoinPing](https://t.me/CoinPingAlertBot)__ : _Multi-condition crypto price alerts via Telegram: price thresholds, 24h % change, and cross-exchange spreads. [Open Source](https://github.com/SeigeC/coinping-bot). Free tier: 3 alerts._
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
+ - __[Mitup](https://t.me/mitupbot?start=src_awesome)__ : _Organize meetups with your Telegram groups without adding a bot to them: RSVPs, waiting lists, and reminders in each person's timezone. [Open Source](https://gitlab.com/meetupbot/mitup-telegram-bot). [Website](https://mitup.social)._
 
   - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
 


### PR DESCRIPTION
Mitup is a bot for organizing meetups with your groups. You create a meeting in a private chat with the bot, share one card into the group, and it tracks who is coming, with RSVPs, a waiting list, and reminders in each person's own timezone. The bot never joins the group itself.

It started in 2015 as a script to organize raid nights for a gaming clan, back when the Bot API was a month old, and it has been running ever since: free, no ads, MIT-licensed, and translated into six languages by its community. Docs at https://mitup.social, source at https://gitlab.com/meetupbot/mitup-telegram-bot.

Disclosure: I am the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Mitup to the “Other Bots” list, with links to its Telegram bot, meetup features, open-source repository, and website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->