### PR TITLE
Add CaptainPost to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
  - __[DeepAlpha Bot](https://t.me/DeepAlphaVault_bot)__ : _AI crypto trading bot. Manage AI, Grid, and DCA bots across 12 exchanges from Telegram. Check positions, PnL, balance. Free 7-day trial. [Website](https://deepalphabot.com)_
  - __[CoinPing](https://t.me/CoinPingAlertBot)__ : _Multi-condition crypto price alerts via Telegram: price thresholds, 24h % change, and cross-exchange spreads. [Open Source](https://github.com/SeigeC/coinping-bot). Free tier: 3 alerts._
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
+ - __[CaptainPost](https://t.me/CaptainPost_bot)__ : _Automates publishing across a network of Telegram channels — route posts between the channels you own, with per-route review queues, scheduling, link rewriting and source attribution. Free tier. [Website](https://captainpost.pages.dev)_
 
   - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
 


### PR DESCRIPTION
Adds **CaptainPost** to the *Other Bots* section.

CaptainPost automates publishing across a network of Telegram channels. You
define routes between channels you own, and new posts propagate automatically.
Each route carries its own settings: review before publishing, schedule, link
rewriting, and a source signature appended to syndicated content.

It connects through a Telegram user session rather than only the Bot API, so it
also works with channels where adding a bot as administrator is not possible.

- Bot: https://t.me/CaptainPost_bot
- Website: https://captainpost.pages.dev

Closed-source, free tier available. Its terms permit only channels the user owns
or administrates, or sources that granted permission, with attribution.

Entry follows the existing format of the section and is appended at the end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CaptainPost to the list of other bots.
  * Included details about channel publishing, routing, review queues, scheduling, link rewriting, attribution, and free-tier availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->