### PR TITLE
Add TikTapSaveBot to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
 
   - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
- - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
+  - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
 
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
  - __[Account Created Date](https://t.me/AccountCreatedBot)__ : _Estimate Telegram account creation dates via forwarded messages, usernames, or contacts. Supports multiple languages._
 
   - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
+ - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
 
   ## OpenSource
   


### PR DESCRIPTION
Adds [TikTapSaveBot](https://t.me/TikTapSaveBot), a Telegram bot that downloads TikTok, Instagram and X/Twitter videos without the watermark (HD, inline mode, free tier + Telegram Stars).

- Live URL: https://t.me/TikTapSaveBot
- Actively maintained (inline mode + Telegram Stars payments live as of 2026-08-04)
- Format matches existing entries in the Other Bots section
- Disclosure: I am the author of this bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TikTapSaveBot to the list of available bots.
  * Documented watermark-free HD downloads from TikTok, Instagram, and X/Twitter.
  * Added details about inline usage and free downloads with Telegram Stars access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->