### PR TITLE
Add I Nudge to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
  - __[CaptainPost](https://t.me/CaptainPost_bot)__ : _Automates publishing across a network of Telegram channels — route posts between the channels you own, with per-route review queues, scheduling, link rewriting and source attribution. Free tier. [Website](https://captainpost.pages.dev)_
  - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
  - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
+ - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
 
   ## OpenSource
   


### PR DESCRIPTION
Adds I Nudge under Other Bots.

It's a reminder assistant that works the other way round from a to-do list: you
write what you need to do in plain language — typed or as a voice note — and it
messages you with a morning briefing and a heads-up before each item. One tap to
close a task. It replies in the language you write to it in.

- Bot: https://t.me/mynudgebot
- Website: https://inudge.io

Disclosure: I built it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the I Nudge Telegram bot to the “Other Bots” list, including its link, description, and website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->