### PR TITLE
Add lora.pro bot to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
  - __[Joba Search](https://t.me/joba_search_bot)__ : _Aggregates game-industry job postings from Russian-language Telegram channels, with AI filtering._
  - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
  - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
+ - __[lora.pro](https://t.me/mono_me_bot)__ : _AI photo studio: send a photo, pick a ready style preset, get a portrait back that keeps your face. Also photo-to-video, sticker packs and photo restoration. [Website](https://lora.pro)_
 
   ## OpenSource
   


### PR DESCRIPTION
https://t.me/mono_me_bot — website: https://lora.pro

I'm the developer. The bot is an AI photo studio: send 1-3 photos of yourself, pick a ready style preset, and get a portrait back in about 10 seconds with your face preserved. It also makes Telegram sticker packs, restores old photos and turns a photo into a short video. Free starter tokens on sign-up.

One line added to the bottom of Other Bots, same format as the surrounding entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lora.pro to the Movie and TV Series Bots section.
  * Highlights AI photo studio capabilities, including portrait generation, photo-to-video conversion, sticker packs, and photo restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->