### PR TITLE
Add QuickRadar to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
  - __[Joba Search](https://t.me/joba_search_bot)__ : _Aggregates game-industry job postings from Russian-language Telegram channels, with AI filtering._
  - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
  - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
+ - __[QuickRadar](https://t.me/QuickRadarBot)__ : _Modular crypto alerts & arbitrage monitoring — visual no-code rule builder for price, funding, open interest and executable spread across 14 exchanges (CEX + DEX), delivered in Telegram. [Website](https://quickradar.win)_
 
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@
  - __[Joba Search](https://t.me/joba_search_bot)__ : _Aggregates game-industry job postings from Russian-language Telegram channels, with AI filtering._
  - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
  - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
- - __[QuickRadar](https://t.me/QuickRadarBot)__ : _Modular crypto alerts & arbitrage monitoring — visual no-code rule builder for price, funding, open interest and executable spread across 14 exchanges (CEX + DEX), delivered in Telegram. [Website](https://quickradar.win)_
+  - __[QuickRadar](https://t.me/QuickRadarBot)__ : _Modular crypto alerts & arbitrage monitoring — visual no-code rule builder for price, funding, open interest and executable spread across 14 exchanges (CEX + DEX), delivered in Telegram. [Website](https://quickradar.win)_
 
   ## OpenSource
   


### PR DESCRIPTION
Adds QuickRadar (`@QuickRadarBot`) to the "Other Bots" section, alongside the other crypto alert bots (CoinPing, DeepAlpha Bot).

QuickRadar is a modular crypto alert and arbitrage-monitoring bot — build custom alert rules through a visual, no-code builder for price, funding rate, open interest, and cross-exchange executable spread across 14 exchanges, delivered via Telegram.

- Bot: https://t.me/QuickRadarBot
- Website: https://quickradar.win

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the “Other Bots” section by aligning the QuickRadar entry with neighboring entries.
  * Added lora.pro to the list of other bots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->