### PR TITLE
Add 5 bots to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@
  - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
  - __[QuickRadar](https://t.me/QuickRadarBot)__ : _Modular crypto alerts & arbitrage monitoring — visual no-code rule builder for price, funding, open interest and executable spread across 14 exchanges (CEX + DEX), delivered in Telegram. [Website](https://quickradar.win)_
  - __[lora.pro](https://t.me/mono_me_bot)__ : _AI photo studio: send a photo, pick a ready style preset, get a portrait back that keeps your face. Also photo-to-video, sticker packs and photo restoration. [Website](https://lora.pro)_
+ - __[WhisperLockBot](https://t.me/WhisperLockBot)__ : _Sends a locked message only the intended recipient can open, inline. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+ - __[NudgeRemindBot](https://t.me/NudgeRemindBot)__ : _Sets reminders using six time input formats. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+ - __[AnonInboxProBot](https://t.me/AnonInboxProBot)__ : _Anonymous inbox that collects messages sent through a personal link. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+ - __[SplitTabsBot](https://t.me/SplitTabsBot)__ : _Splits group bills and tracks who owes what. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+ - __[HabitStreakProBot](https://t.me/HabitStreakProBot)__ : _Tracks daily habit check-ins and streaks. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
 
   ## OpenSource
   

--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@
  - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._
  - __[QuickRadar](https://t.me/QuickRadarBot)__ : _Modular crypto alerts & arbitrage monitoring — visual no-code rule builder for price, funding, open interest and executable spread across 14 exchanges (CEX + DEX), delivered in Telegram. [Website](https://quickradar.win)_
  - __[lora.pro](https://t.me/mono_me_bot)__ : _AI photo studio: send a photo, pick a ready style preset, get a portrait back that keeps your face. Also photo-to-video, sticker packs and photo restoration. [Website](https://lora.pro)_
- - __[WhisperLockBot](https://t.me/WhisperLockBot)__ : _Sends a locked message only the intended recipient can open, inline. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
- - __[NudgeRemindBot](https://t.me/NudgeRemindBot)__ : _Sets reminders using six time input formats. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
- - __[AnonInboxProBot](https://t.me/AnonInboxProBot)__ : _Anonymous inbox that collects messages sent through a personal link. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
- - __[SplitTabsBot](https://t.me/SplitTabsBot)__ : _Splits group bills and tracks who owes what. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
- - __[HabitStreakProBot](https://t.me/HabitStreakProBot)__ : _Tracks daily habit check-ins and streaks. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+  - __[WhisperLockBot](https://t.me/WhisperLockBot)__ : _Sends a locked message only the intended recipient can open, inline. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+  - __[NudgeRemindBot](https://t.me/NudgeRemindBot)__ : _Sets reminders using six time input formats. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+  - __[AnonInboxProBot](https://t.me/AnonInboxProBot)__ : _Anonymous inbox that collects messages sent through a personal link. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+  - __[SplitTabsBot](https://t.me/SplitTabsBot)__ : _Splits group bills and tracks who owes what. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
+  - __[HabitStreakProBot](https://t.me/HabitStreakProBot)__ : _Tracks daily habit check-ins and streaks. Free tier, one-time 150 Stars Pro upgrade, Mini App included._
 
   ## OpenSource
   


### PR DESCRIPTION
## Summary

Adds five live Telegram bots to the end of the **Other Bots** section under Telegram Bots, following the existing `- __[Name](link)__ : _Description._` format from Contributing.md. All five are Telegram Main Mini Apps.

- **WhisperLockBot** — sends a locked message only the intended recipient can open, inline.
- **NudgeRemindBot** — sets reminders using six time input formats.
- **AnonInboxProBot** — anonymous inbox that collects messages sent through a personal link.
- **SplitTabsBot** — splits group bills and tracks who owes what.
- **HabitStreakProBot** — tracks daily habit check-ins and streaks.

All five run a free tier with an optional one-time 150 Stars Pro upgrade.

## Test plan

- [x] Entries appended at the end of the Other Bots section, no other content touched
- [x] Format matches existing `- __[Name](link)__ : _Description._` entries
- [x] Links verified live (t.me/<username>)

https://claude.ai/code/session_01CuouAdGh6BJqftLbExH6KH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected the indentation of five existing entries in the “Other Bots” list for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->