### PR TITLE
Add Vacato (@vacato_bot) to Other Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
   - __[Mitup](https://t.me/mitupbot?start=src_awesome)__ : _Organize meetups with your Telegram groups without adding a bot to them: RSVPs, waiting lists, and reminders in each person's timezone. [Open Source](https://gitlab.com/meetupbot/mitup-telegram-bot). [Website](https://mitup.social)._
   - __[CaptainPost](https://t.me/CaptainPost_bot)__ : _Automates publishing across a network of Telegram channels — route posts between the channels you own, with per-route review queues, scheduling, link rewriting and source attribution. Free tier. [Website](https://captainpost.pages.dev)_
   - __[Crawlbench Alerts](https://t.me/CrawlbenchAlertsBot)__ : _Telegram bot that sends Facebook Marketplace match alerts from Crawlbench. [Website](https://crawlbench.com)_
+  - __[Vacato](https://t.me/vacato_bot)__ : _RDAP domain availability watchlist alerts via Telegram (also email/Slack). Free 10 domains. Not a registrar or drop-catcher. [Website](https://vacato.io)_
   - __[Joba Search](https://t.me/joba_search_bot)__ : _Aggregates game-industry job postings from Russian-language Telegram channels, with AI filtering._
   - __[TikTapSaveBot](https://t.me/TikTapSaveBot)__ : _Downloads TikTok, Instagram and X/Twitter videos without the watermark in HD, right inside Telegram. 3 free downloads, then unlock via Telegram Stars. Works inline._
   - __[I Nudge](https://t.me/mynudgebot?start=src_awesome)__ : _Proactive reminders and a morning briefing for tasks you capture by text or voice note, in your own language. One tap to close. [Website](https://inudge.io)._


### PR DESCRIPTION
## Summary
Add [@vacato_bot](https://t.me/vacato_bot) under **Other Bots** — Telegram alerts for an RDAP domain availability watchlist ([Vacato](https://vacato.io)). Free tier: 10 domains. Not a drop-catcher.

Peers: alert-style bots such as Crawlbench Alerts / CoinPing.

Affiliation: I maintain Vacato.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Vacato to the list of other bots, highlighting domain availability watchlist alerts through Telegram, email, and Slack.
  - Notes that the service is free for monitoring up to 10 domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->